### PR TITLE
as a card is played

### DIFF
--- a/content.md
+++ b/content.md
@@ -309,6 +309,9 @@ cards in hand. Whenever an effect changes your hand size or adds or
 removes cards from your hand, immediately discard down to or draw up to
 match your hand size.
 
+> **ADVANCED**
+> Some effects take place "as a card is played". All cards played during that time are not replaced until all effects during that window are handeled.
+
 ### **Requirements for Playing Cards**
 
 Each library card has symbols on the attribute bar (the marble stripe on


### PR DESCRIPTION
The unique timing which takes place before the usual redraw should be added for clarity's sake, as this is not something one can easily deduce from card text and current rules.