### PR TITLE
Suggestion

### DIFF
--- a/content.md
+++ b/content.md
@@ -1847,7 +1847,7 @@ strength of 1.
 
 **Dodge:** A dodge strike deals no damage, but it protects the dodging
 minion and their possessions from the effects of the opposing strike.
-Retainers are not protected, however. A dodge is effective at any range.
+A dodge is effective at any range.
 A dodge protects even from the effects of a strike done with first
 strike (see [**First Strike**](https://www.vekn.net/rulebook#first-strike)). A
 dodge is a strike, even though it is solely defensive. It represents the


### PR DESCRIPTION
Suggestion to slighly simplify Dodge: Remove that Retainers are not protected. So dodge protects not only equipment, but all possessions.

Reasoning: It seems like a very corner case, given the special setup which needs to be met for retainers to be targeted. It also is an exception to the rule which does not provide any real tactical depth and is hard to memorize.