### PR TITLE
Rule change: cannot wake during "as played" anymore.

### DIFF
--- a/content.md
+++ b/content.md
@@ -2821,11 +2821,7 @@ at the end of the game wins.
 
 **Wake:** A vampire that wakes during an action can attempt to block
 that action and/or play reaction cards as though unlocked for the
-duration of the action. Wake effects can always be played during the "as
-a card is played" window, in order to play other reaction cards that
-must be played in that window. A reaction card that unlocks a vampire
-but does not wake it is not considered as a wake effect and cannot be
-played during the "as a card is played" window.
+duration of the action.
 
 **Withdraw:** An attempt to leave the game by a Methuselah who has run
 out of cards in their library.

--- a/content.md
+++ b/content.md
@@ -290,8 +290,7 @@ play area upon resolution.
 Some cards such as action cards are not resolved immediately; in that case, they are temporarily out of play between the moment they are played and the moment they reach resolution.
 
 > **ADVANCED RULES**\
-> Some effects can cancel a card "as it is played." These effects, as
-> well as [**wake effects**](https://www.vekn.net/rulebook/8-glossaries#wake),
+> Some effects can cancel a card "as it is played." These effects
 > are the only effects allowed during the "as played" time period of
 > another card. Even drawing to replace cards, comes after this time
 > period.


### PR DESCRIPTION
## This is a rule change.

Given the last release, it seems mandatory to remove this old exception. It impacts/nerfs a few [cancel reactions](https://rulings.krcg.org/groups.html?uid=G00062) as well as reflex "frenzy cancellation" cards (thanks Deep Song), but this is cornercase anyway IMHO. On the other hand, it makes Unleashing the Bestial Soul (and any other future modifier) work without surprises.

Right now, rulemongers can use this exception to **play a wake after Unleashing the Bestial Soul has been played but before its effect is enacted**, in the "as played" window. It's very unnatural and unexpected for most players. I had to explain this multiple times even to veterans until they understood what was possible here.

![Unleashing the Bestial Soul](https://static.krcg.org/card/unleashingthebestialsoul.jpg)

### More musings
This would also make [cancelation without action](https://rulings.krcg.org/groups.html?uid=G00063) a bit clearer.
The ruling on Rewind Time has to state you cannot wake when there is no action, although the rulebook says you can wake in the "as played" window, and we lot just agreed it was fine to wake in the "as played" window of an action to cancel said action, even though if it is the "as played" window, there is no action _yet_... It is not too consistent TBH.