### PR TITLE
Adding Step "After Action Resolution"

### DIFF
--- a/content.md
+++ b/content.md
@@ -1220,7 +1220,7 @@ action and lock the minion who is performing the action.
 
 Some cards are played "as the action is announced”, those cards must be played before regular action modifier cards and reaction cards. 
 
-**2. Target Methuselah(s) may try to block** the action with any of
+**2. Resolve block attempts** Target Methuselah(s) may try to **block** the action with any of
 their ready unlocked minions or if the action does not target another
 Methuselah, or targets a card controlled by the acting Methuselah, then
 the minions of the prey and predator may try to block.
@@ -1229,8 +1229,11 @@ the minions of the prey and predator may try to block.
 - If a **block attempt is successful**, then the blocking minion locks
 and enters combat with the acting minion.
 
-**3.** If no attempt is successful and no more attempts are made, then
+**3. Resolve the action** If no attempt is successful and no more attempts are made, then
 the **action is successful**, and the cost of the action is paid.
+
+**4. After action resolution** After all effects are handeled, there is a chance to play cards which are only usable after action resolution. This is considered the final step of the action.
+
 
 **Action modifiers** and **reaction cards** can be played at any time
 before resolution during an action, with the acting Methuselah getting
@@ -1423,6 +1426,9 @@ succeeds; the cost is not paid if the action is blocked. The costs of
 action modifiers and reaction cards are always paid when the cards are
 played, regardless of the success of the action.
 
+**4. After Action resolution** 
+
+After all effects are handeled, there is a chance to play cards which are only usable after action resolution. This is considered the final step of the action. If an action card was used, it is now burned.
 
 
 ### **Politics**


### PR DESCRIPTION
In a discussion in Discord came up regarding Wakes, the main issue seemed imho that "after action resolution" is a window which has been ruled multiple times as part of the action. Core cards like Freak Drive refer to this window as well. However, it isn't part of the rulebook yet. So for clarity, I'd like to suggest to add this step officially and define it as part of the action (which is already the case per rulings). The headlines for the overview have been aligned with the headlines used later on (new in italics):

> ***2. Resolve block attempts*** Target Methuselah(s) may try to **block** the action with any of (...)
> ***3. Resolve the action*** If no attempt is successful and no more attempts (...)

suggested additon:

> **4. After action resolution** After all effects are handeled (...)

Additionally, I'd like to suggest that the newly formalized window could also the window where action cards are moved to the ash heap: Current text references that action cards are out of play (Step 1), but it doesn't spell out exactly when they are moved to the ash heap. 

> Step 1: Any card required for the action is played (face up) at this time, but is temporarily set aside (out of play) until the action resolves.
> Step 3: If the action is successful (all block attempts were unsuccessful), then the cost of the action is paid and the effects of the successful action take place.

suggested addition:

> Step 4: After all effects are handeled, there is a chance to play cards which are only usable after action resolution. This is considered the final step of the action. If an action card was used, it is now burned.

The suggested change would have little impact on the game but that action cards do not need to be put into the ash heap and then moved out of it if an action is continued by Form of Mist or similar - which simplifies things imho.