### PR TITLE
Update Oust Language

### DIFF
--- a/content.md
+++ b/content.md
@@ -2115,11 +2115,12 @@ be saved for later.
 
 
 When a Methuselah runs out of pool counters, they are ousted from the
-game. If you are ousted, all the cards you control are removed from the
-game. Any of your rivals' cards you control are returned to them at the
-end of the game. Any of your cards controlled by other Methuselahs
-remain in play as normal. The game continues until only one Methuselah
-is left.
+game. If you are ousted, you immediately yield all contests and all the
+cards you own that are not controlled by other Methuselahs and any cards
+owned by other Methuselahs that you control or are in your uncontrolled
+region are removed from the game. Any of your rivals' cards you control
+are returned to them at the end of the game. The game continues until
+only one Methuselah is left.
 
 You get 1 victory point and 6 pool counters from the blood bank whenever
 your prey is ousted (no matter how or by whom your prey was ousted). You


### PR DESCRIPTION
The original oust language uses "controlled" with a different meaning than the rest of the rulebook.  When ousted it was using controlled to mean everything in your "play area," but controlled _has_ a specific meaning in VTES.  The language here must reflect that because RAW would mean that an ousted Methuselah's hand, library, unctronlled region, ash heap, and contested cards would not be removed from the game because, by definition, none of those are "controlled."

The cases that need to be solved to be accurate with what we want:
- The ousted Methuselah's hand, ash heap, library, crypt, and uncontrolled region are removed
- All contested cards are immediately yielded
- All controlled cards are removed

I am not thrilled by the long sentence that I made to describe that.  It was initially shorter, but I found additional cases as I was writing.  Perhaps a bulleted list would be better?

Regardless, the use of "controlled" in the original text is misleading at best and RAW a terrible description of the intent.